### PR TITLE
Fix Tab 2 Related Co Table Output

### DIFF
--- a/R/test_func.R
+++ b/R/test_func.R
@@ -51,6 +51,7 @@ make_co_type <- function(input_value) {
     slice(1) %>%
     select(BusinessType) %>%
     dashTable::df_to_list()
+  selected_PID <- selected_PID[!is.na(selected_PID)]
   columns <- c("BusinessType") %>% purrr::map(function(col) list(name = "Primary Business Type", id = col))
   list(selected_PID, columns)
 

--- a/app.R
+++ b/app.R
@@ -16,8 +16,8 @@ library(here)
 devtools::load_all(".")
 
 # define column names
-tbl_col_ids <- c("NAME", "LEVEL", "CCTL")
-tbl_col_names <- c("Name", "Level", "Country of Control")
+tbl_col_ids <- c("NAME", "LEVEL", "CRES")
+tbl_col_names <- c("Name", "Level", "Country")
 
 # Load CSS Styles
 css <- custom_css()


### PR DESCRIPTION
This PR is to fix the bug that was created when the vbr file was changed. Tab 2 related company table should be populating properly, ordered by level.